### PR TITLE
Fix configuration of sorting and hidden columns

### DIFF
--- a/footable.module
+++ b/footable.module
@@ -225,15 +225,15 @@ function template_preprocess_footable_view(&$vars) {
     }
 
     // Sorting.
-    if (!empty($options['footable']['component']['sorting']['enabled'])) {
+    if (!empty($options['footable']['component']['sorting']['enabled']) && isset($vars['header'][$field])) {
       $vars['header'][$field] = check_plain(!empty($field_handler) ? $field_handler->label() : '');
 
       if (empty($options['info'][$field]['sortable']) || !$field_handler->click_sortable()) {
-        $vars['column_attributes'][$column]['data-sortable'] = FALSE;
+        $vars['column_attributes'][$column]['data-sortable'] = 'false';
       }
       else {
         if (!empty($options['default']) && $options['default'] == $field) {
-          $vars['column_attributes'][$column]['data-sorted'] = TRUE;
+          $vars['column_attributes'][$column]['data-sorted'] = 'true';
 
           if (!empty($options['info'][$field]['default_sort_order'])) {
             $vars['column_attributes'][$column]['data-direction'] = strtoupper($options['info'][$field]['default_sort_order']);


### PR DESCRIPTION
Thanks for porting this to Backdrop. 

I encountered two bugs which are also in the original Drupal version. The patches in Drupal issues https://www.drupal.org/project/footable/issues/2975723 and https://www.drupal.org/project/footable/issues/3341045 are the same as this pull request.

In short: hidden columns are now hidden (even when sorting is enabled) and configuration of sortable columns and default order is applied correctly in footable (i.e. it is now possible to have not-sortable columns ).